### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ReactNativeRedditReader
 
 ![alt tag](http://i.imgur.com/sh7JnZG.gif)
 
-##Running
+## Running
 1. Run `npm install` inside the folder, this will install react-native and other dependencies and will take some time.
 
 2. Open the project file at `ios/ReactNativeRedditReader.xcodeproj`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
